### PR TITLE
fix: github-readme-stats preview links to prod links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,12 +5,12 @@ Hi. I’m Bruno. I am a Software Developer from Brazil 🇧🇷.
 I work at [Shawee](https://shawee.io) as a Web Developer. For more information about me,
 check out [brunos3d.github.io](https://brunos3d.github.io).
 
-![Bruno's GitHub stats](https://github-readme-stats.anuraghazra1.vercel.app/api?username=BrunoS3D&show_icons=true&hide_border=true)
+![Bruno's GitHub stats](https://github-readme-stats.vercel.app/api?username=BrunoS3D&show_icons=true&hide_border=true)
 
 <a href="https://github.com/BrunoS3D/FastPlay">
-  <img align="left" src="https://github-readme-stats.anuraghazra1.vercel.app/api/pin/?username=BrunoS3D&repo=FastPlay" />
+  <img align="left" src="https://github-readme-stats.vercel.app/api/pin/?username=BrunoS3D&repo=FastPlay" />
 </a>
 
 <a href="https://github.com/BrunoS3D/brunos3d.github.io">
-  <img align="left" src="https://github-readme-stats.anuraghazra1.vercel.app/api/pin/?username=BrunoS3D&repo=brunos3d.github.io" />
+  <img align="left" src="https://github-readme-stats.vercel.app/api/pin/?username=BrunoS3D&repo=brunos3d.github.io" />
 </a>


### PR DESCRIPTION
Hey there, sorry i accidentally put preview links on the docs instead of production links, and you've copied them. i've changed them to production version.. :D